### PR TITLE
Refactor: Hide API key for security

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,6 +19,10 @@ android {
         vectorDrawables {
             useSupportLibrary true
         }
+
+        Properties properties = new Properties()
+        properties.load(project.rootProject.file("local.properties").newDataInputStream())
+        buildConfigField "String", "API_KEY", "\"${properties.getProperty("API_KEY")}\""
     }
 
     buildTypes {
@@ -36,6 +40,7 @@ android {
     }
     buildFeatures {
         compose true
+        buildConfig true
     }
     composeOptions {
         kotlinCompilerExtensionVersion '1.3.2'

--- a/app/src/main/java/com/example/personalizedmusicapp/MainActivity.kt
+++ b/app/src/main/java/com/example/personalizedmusicapp/MainActivity.kt
@@ -61,21 +61,6 @@ interface ApiService {
     ): Response<PlayListItemsResponse>
 }
 
-//@Composable
-//fun ItemCard(item: Item) {
-//    OutlinedCard(
-//        modifier = Modifier
-//            .fillMaxWidth()
-//            .padding(5.dp)
-//    ) {
-//        Text(item.snippet.title)
-//        Text(item.snippet.position)
-//        Text(item.snippet.resourceId.videoId)
-//
-//        YoutubePlayer(youtubeVideoId = item.snippet.resourceId.videoId)
-//    }
-//}
-
 @OptIn(ExperimentalMaterial3Api::class)
 class MainActivity : ComponentActivity() {
 

--- a/app/src/main/java/com/example/personalizedmusicapp/screen/HomeScreen.kt
+++ b/app/src/main/java/com/example/personalizedmusicapp/screen/HomeScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import com.example.personalizedmusicapp.BuildConfig
 import com.example.personalizedmusicapp.YoutubePlayer
 import com.example.personalizedmusicapp.data.Item
 import com.example.personalizedmusicapp.data.PlayListItemsResponse
@@ -77,7 +78,7 @@ fun HomeScreen(
             val part = "snippet"
             val maxResults = "50"
             val playlistId = "PL9JwhzITbbGZGA5qjHDbVfNQnK5Sc_XWG"
-            val key = "AIzaSyBKxF26cbuvhSHdc0otnKePjQMi4MLp5GQ"
+            val key = BuildConfig.API_KEY
 
             val response = apiService.getPlaylistItems(part, maxResults, playlistId, key)
 


### PR DESCRIPTION
Issue: API key should not be exposed in the source code directly. Attacker can make use of the key exposed in the source code and make requests to the API with the key directly in the name of the owner. This can lead to issues including reaching the usage limits and high costs. 

Refactor/Fix: One of the best and common practices to hide the API key from source code in the version control is to put the key into the "local.properties" file since the "local.properties" file is specified in the "gitignore" file. Therefore, the "local.properties" file will not be included in the version control/GitHub and thus the key within the file. The API key also got regenerated in case attacker can still be able to locate the API key by looking into the previous commits/versions. 

Reference: 
Google - Securing an API key: https://cloud.google.com/api-keys/docs/overview?_ga=2.254685192.-1616374754.1699387075
Protect your API keys from Reverse Engineering in Android: https://medium.com/@khadijahameed415/protect-your-api-keys-in-android-134947280546 