### PR TITLE
Debug: Resolve recomposition issue in FavouritesScreen by adding unique keys

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">

--- a/app/src/main/java/com/example/personalizedmusicapp/model/VideoViewModel.kt
+++ b/app/src/main/java/com/example/personalizedmusicapp/model/VideoViewModel.kt
@@ -21,7 +21,7 @@ class VideoViewModel (private val dao: VideoDao): ViewModel() {
         state.copy(
             videos= videos
         )
-    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), VideoState())
+    }.stateIn(  viewModelScope, SharingStarted.WhileSubscribed(5000), VideoState())
 
     fun onEvent(event: VideoEvent) {
         when(event) {

--- a/app/src/main/java/com/example/personalizedmusicapp/screen/FavouritesScreen.kt
+++ b/app/src/main/java/com/example/personalizedmusicapp/screen/FavouritesScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.key
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -71,7 +72,10 @@ fun FavouritesScreen(
             verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
             items(state.videos) { video ->
-                FavItemCard(youtubeId = video.youtubeId , onEvent = onEvent)
+                key(video.youtubeId)
+                {
+                    FavItemCard(youtubeId = video.youtubeId , onEvent = onEvent)
+                }
             }
             item { Row(modifier = Modifier.height(120.dp)){} }
         }


### PR DESCRIPTION
Issue: The components (YoutubePlayer/FavItemCard) inside the FavouritesScreen.kt were not recomposing immediately when a video was removed (or the state changed). 

Debug/Fix: To address the recomposition issue, the key utility composable can be added to the LazyColumn items. The key composable is used to provide a unique identifier for each item in the list, and when the unique identifier changes, compose understands that the corresponding item (i.e., the YoutubePlayer/FavItemCard) needs to be recomposed.

Official Documentation about the key utility composable in Android Studio:
https://developer.android.com/reference/kotlin/androidx/compose/runtime/package-summary#key(kotlin.Array,kotlin.Function0)

Definition of key: "[key](https://developer.android.com/reference/kotlin/androidx/compose/runtime/package-summary#key(kotlin.Array,kotlin.Function0)) is a utility composable that is used to "group" or "key" a block of execution inside of a composition. This is sometimes needed for correctness inside of control-flow that may cause a given composable invocation to execute more than once during composition."




