### PR TITLE
Debug: Debug the Add Video Dialog for the youtubeid being there when opened the dialog

### DIFF
--- a/app/src/main/java/com/example/personalizedmusicapp/screen/AddVideoDialog.kt
+++ b/app/src/main/java/com/example/personalizedmusicapp/screen/AddVideoDialog.kt
@@ -8,8 +8,13 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import com.example.personalizedmusicapp.data.Item
 import com.example.personalizedmusicapp.model.VideoEvent
 import com.example.personalizedmusicapp.model.VideoState
 
@@ -21,14 +26,17 @@ fun AddVideoDialog(
     modifier: Modifier = Modifier
 )
 {
+    var youtubeId by remember { mutableStateOf("") }
+
     AlertDialog(
         modifier = modifier,
         onDismissRequest = { onEvent(VideoEvent.HideDialog) },
         title = { Text(text = "Add Video") },
         text = {
             TextField(
-                value = state.youtubeId,
+                value = youtubeId,
                 onValueChange = {
+                    youtubeId = it
                     onEvent(VideoEvent.SetYoutubeId(it))
                 },
                 placeholder = {


### PR DESCRIPTION
Issue: When the Add Video Dialog (the plus logo) got clicked and opened, it should not show any value of YouTube id but only the placeholder "Youtube ID".  However, when a video at the Home Screen got favorite and then removed from favorite (at the same Home Screen), the youtube id of the selected video will somehow be stored and shown in the Add Video Dialog which is not the expected behavior.  The Add Video Dialog should always show a empty value by default (i.e., the placeholder) whenever it get opened. 

Debug/Fix: The reason for this issue being happened is the youtube id was saved into the state/Live Data when the video got selected/favorite/unfavorite at the Home Screen.  Since the Add Favorite Dialog does not need to observe the video state/Live Data but only prompt the user to enter a new YouTube video id, I have used a local variable for being the value of the TextField instead of the video state in the Live Data. 
