### PR TITLE
Debug or Refactor#1: Update database schema and retrieve video duration from YoutubeAPI for a new Player Screen

### DIFF
--- a/app/src/main/java/com/example/personalizedmusicapp/MainActivity.kt
+++ b/app/src/main/java/com/example/personalizedmusicapp/MainActivity.kt
@@ -1,10 +1,12 @@
 package com.example.personalizedmusicapp
 
 import android.annotation.SuppressLint
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
+import androidx.annotation.RequiresApi
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -12,9 +14,11 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.outlined.FavoriteBorder
 import androidx.compose.material.icons.outlined.Home
+import androidx.compose.material.icons.outlined.PlayArrow
 import androidx.compose.material.icons.outlined.Search
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -46,6 +50,7 @@ import com.example.personalizedmusicapp.model.VideoViewModel
 import com.example.personalizedmusicapp.room.VideoDatabase
 import com.example.personalizedmusicapp.screen.FavouritesScreen
 import com.example.personalizedmusicapp.screen.HomeScreen
+import com.example.personalizedmusicapp.screen.PlayerScreen
 import com.example.personalizedmusicapp.ui.theme.PersonalizedMusicAppTheme
 import retrofit2.Response
 import retrofit2.http.GET
@@ -81,6 +86,7 @@ class MainActivity : ComponentActivity() {
         }
     )
 
+    @RequiresApi(Build.VERSION_CODES.O)
     @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -106,6 +112,7 @@ class MainActivity : ComponentActivity() {
                             composable("home") { HomeScreen(state = state, onEvent=viewModel::onEvent)}
                             composable("search") { SearchScreen() }
                             composable("favourites") { FavouritesScreen(state=state, onEvent=viewModel::onEvent) }
+                            composable("player") { PlayerScreen(state=state, onEvent=viewModel::onEvent) }
                         }
                     }
                 }
@@ -127,6 +134,7 @@ fun BottomNavigationBar(navController: NavController) {
         BottomNavItem("Home", Icons.Filled.Home, Icons.Outlined.Home, "home"),
         BottomNavItem("Search", Icons.Filled.Search, Icons.Outlined.Search, "search"),
         BottomNavItem("Favourites", Icons.Filled.Favorite, Icons.Outlined.FavoriteBorder, "favourites"),
+        BottomNavItem("Player", Icons.Filled.PlayArrow, Icons.Outlined.PlayArrow, "player")
     )
 
     NavigationBar(

--- a/app/src/main/java/com/example/personalizedmusicapp/data/ContentDetails.kt
+++ b/app/src/main/java/com/example/personalizedmusicapp/data/ContentDetails.kt
@@ -1,0 +1,6 @@
+package com.example.personalizedmusicapp.data
+
+data class ContentDetails (
+    val videoId: String,
+    val duration : String
+)

--- a/app/src/main/java/com/example/personalizedmusicapp/data/Item.kt
+++ b/app/src/main/java/com/example/personalizedmusicapp/data/Item.kt
@@ -4,5 +4,6 @@ data class Item(
     val etag: String,
     val id: String,
     val kind: String,
-    val snippet: Snippet
+    val snippet: Snippet,
+    val contentDetails : ContentDetails
 )

--- a/app/src/main/java/com/example/personalizedmusicapp/model/VideoEvent.kt
+++ b/app/src/main/java/com/example/personalizedmusicapp/model/VideoEvent.kt
@@ -3,10 +3,10 @@ package com.example.personalizedmusicapp.model
 import com.example.personalizedmusicapp.room.Video
 
 sealed interface VideoEvent {
-    object SaveVideo: VideoEvent
-    data class SetYoutubeId(val youtubeId: String): VideoEvent
-    object ShowDialog: VideoEvent
-    object HideDialog: VideoEvent
-    data class DeleteVideo (val video: Video): VideoEvent
-    data class DeleteVideoByYoutubeId (val youtubeId: String): VideoEvent
+    object SaveVideo : VideoEvent
+    data class SetVideo(val youtubeId: String, val title: String, val duration: String) : VideoEvent
+    object ShowDialog : VideoEvent
+    object HideDialog : VideoEvent
+    data class DeleteVideo(val video: Video) : VideoEvent
+    data class DeleteVideoByYoutubeId(val youtubeId: String) : VideoEvent
 }

--- a/app/src/main/java/com/example/personalizedmusicapp/model/VideoState.kt
+++ b/app/src/main/java/com/example/personalizedmusicapp/model/VideoState.kt
@@ -4,6 +4,8 @@ import com.example.personalizedmusicapp.room.Video
 
 data class VideoState(
     val videos: List<Video> = emptyList(),
-    val youtubeId: String ="",
-    val isAddingVideo: Boolean = false,
+    val youtubeId: String = "",
+    val title: String = "",
+    val duration: String ="",
+    val isAddingVideo: Boolean = false
 )

--- a/app/src/main/java/com/example/personalizedmusicapp/room/Video.kt
+++ b/app/src/main/java/com/example/personalizedmusicapp/room/Video.kt
@@ -10,5 +10,7 @@ data class Video(
     @ColumnInfo(name="video_id")
     val videoId: Int = 0,
     @ColumnInfo(name="youtube_id")
-    val youtubeId: String = ""
+    val youtubeId: String = "",
+    val title: String = "",
+    val duration: String = ""
 )

--- a/app/src/main/java/com/example/personalizedmusicapp/screen/AddVideoDialog.kt
+++ b/app/src/main/java/com/example/personalizedmusicapp/screen/AddVideoDialog.kt
@@ -26,18 +26,15 @@ fun AddVideoDialog(
     modifier: Modifier = Modifier
 )
 {
-    var youtubeId by remember { mutableStateOf("") }
-
     AlertDialog(
         modifier = modifier,
         onDismissRequest = { onEvent(VideoEvent.HideDialog) },
         title = { Text(text = "Add Video") },
         text = {
             TextField(
-                value = youtubeId,
+                value = state.youtubeId,
                 onValueChange = {
-                    youtubeId = it
-                    onEvent(VideoEvent.SetYoutubeId(it))
+                    onEvent(VideoEvent.SetVideo(it, "", "04:00"))
                 },
                 placeholder = {
                     Text(text = "Youtube ID")

--- a/app/src/main/java/com/example/personalizedmusicapp/screen/FavouritesScreen.kt
+++ b/app/src/main/java/com/example/personalizedmusicapp/screen/FavouritesScreen.kt
@@ -74,7 +74,7 @@ fun FavouritesScreen(
             items(state.videos) { video ->
                 key(video.youtubeId)
                 {
-                    FavItemCard(youtubeId = video.youtubeId , onEvent = onEvent)
+                    FavItemCard(youtubeId = video.youtubeId, title = video.title, onEvent = onEvent)
                 }
             }
             item { Row(modifier = Modifier.height(120.dp)){} }
@@ -83,8 +83,7 @@ fun FavouritesScreen(
 }
 
 @Composable
-fun FavItemCard(youtubeId: String, onEvent: (VideoEvent) -> Unit) {
-
+fun FavItemCard(youtubeId: String, title: String, onEvent: (VideoEvent) -> Unit) {
     OutlinedCard(
         modifier = Modifier
             .fillMaxWidth()
@@ -92,7 +91,7 @@ fun FavItemCard(youtubeId: String, onEvent: (VideoEvent) -> Unit) {
     ) {
         Row(modifier = Modifier.fillMaxWidth().padding(5.dp),
             verticalAlignment = Alignment.CenterVertically){
-            Text(youtubeId)
+            Text(title)
             Row(modifier= Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.End) {
                 IconButton(onClick = {

--- a/app/src/main/java/com/example/personalizedmusicapp/screen/PlayerScreen.kt
+++ b/app/src/main/java/com/example/personalizedmusicapp/screen/PlayerScreen.kt
@@ -1,0 +1,263 @@
+package com.example.personalizedmusicapp.screen
+
+import android.os.Build
+import android.os.CountDownTimer
+import androidx.annotation.RequiresApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.ArrowForward
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedCard
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.personalizedmusicapp.YoutubePlayer
+import com.example.personalizedmusicapp.model.VideoEvent
+import com.example.personalizedmusicapp.model.VideoState
+import java.time.LocalTime
+
+@RequiresApi(Build.VERSION_CODES.O)
+@Composable
+fun PlayerScreen(
+    state: VideoState,
+    onEvent: (VideoEvent) -> Unit) {
+
+    if (!state.videos.isEmpty()){
+        ScreenWithVideoList(state, onEvent)
+    } else {
+        Column (
+            modifier = Modifier.fillMaxSize(),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                text = "Your favourite list is empty.",
+                fontWeight = FontWeight.ExtraBold,
+                fontSize = 28.sp
+            )
+        }
+    }
+}
+
+@Composable
+fun myPlayer(idx: Int, state: VideoState){
+    OutlinedCard(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(5.dp)
+    ){
+        if (idx != -1) {
+            key(state.videos[idx].youtubeId) {
+                YoutubePlayer(youtubeVideoId = state.videos[idx].youtubeId)
+            }
+        }
+    }
+}
+
+@Composable
+fun ScreenWithVideoList(state: VideoState, onEvent: (VideoEvent) -> Unit)
+{
+    // The index of the current video
+    var idx by remember {
+        mutableStateOf(0)
+    }
+
+    // It will refresh the counter when it is changed from false to true.
+    var check by remember {
+        mutableStateOf(true)
+    }
+
+    val currentTime: LocalTime = LocalTime.now()
+
+    var second by remember {
+        mutableStateOf(currentTime.second)
+    }
+
+    // The minute of the counter
+    var counterMin by remember {
+        mutableStateOf(state.videos[0].duration.substringBefore(":").toInt())
+    }
+
+    // The second of the counter
+    var counterSec by remember {
+        mutableStateOf(state.videos[0].duration.substringAfter(":").toInt())
+    }
+
+
+    Column(
+        modifier = Modifier
+            .padding(5.dp)
+            .fillMaxWidth(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        myPlayer(idx = idx, state = state)
+
+        // Refreshes the counter if check is true.
+        if (check) {
+
+            val currentTime: LocalTime = LocalTime.now()
+
+            if (currentTime.second - second == 1 || currentTime.second - second == -59) {
+                second = currentTime.second
+                counterSec--
+            }
+
+            if (counterSec < 0) {
+                counterSec = 59
+                counterMin--
+            }
+
+            if (counterMin <= 0 && counterSec == 0) {
+                idx++
+                if (idx == state.videos.count())
+                    idx = 0
+                counterMin = state.videos[idx].duration.substringBefore(":").toInt()
+                counterSec = state.videos[idx].duration.substringAfter(":").toInt()
+            }
+
+            check = false
+        }
+
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            val minStr = String.format("%02d", counterMin)
+            val secStr = String.format("%02d", counterSec)
+            Text(state.videos[idx].title)
+            Text("${minStr}:$secStr | ${idx + 1} / ${state.videos.count()}")
+        }
+
+        Row(
+            modifier = Modifier.padding(10.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            IconButton(
+                modifier = Modifier
+                    .size(40.dp)
+                    .background(
+                        shape = CircleShape,
+                        color = Color.LightGray
+                    ),
+                onClick = {
+                    idx--
+                    if (idx == -1)
+                        idx = state.videos.count() - 1
+                    counterMin = state.videos[idx].duration.substringBefore(":").toInt()
+                    counterSec = state.videos[idx].duration.substringAfter(":").toInt()
+                }) {
+                Icon(
+                    imageVector = Icons.Default.ArrowBack,
+                    contentDescription = "Backward",
+                    tint = Color.White
+                )
+            }
+            Spacer(modifier = Modifier.size(100.dp, 10.dp))
+            IconButton(
+                modifier = Modifier
+                    .size(40.dp)
+                    .background(
+                        shape = CircleShape,
+                        color = Color.LightGray
+                    ),
+                onClick = {
+                    idx++
+                    if (idx == state.videos.count())
+                        idx = 0
+                    counterMin = state.videos[idx].duration.substringBefore(":").toInt()
+                    counterSec = state.videos[idx].duration.substringAfter(":").toInt()
+                }) {
+                Icon(
+                    imageVector = Icons.Default.ArrowForward,
+                    contentDescription = "Forward",
+                    tint = Color.White
+                )
+            }
+        }
+
+        LazyColumn(
+            contentPadding = PaddingValues(16.dp),
+            modifier = Modifier.fillMaxSize(),
+
+            ) {
+            items(state.videos) { video ->
+                PlayItemCard(
+                    title = video.title,
+                    duration = video.duration,
+                    onEvent = onEvent,
+                    youtubeId = video.youtubeId
+                )
+            }
+            item { Row(modifier = Modifier.height(120.dp)){} }
+        }
+    }
+
+    object : CountDownTimer(100, 100) {
+
+        override fun onTick(millisUntilFinished: Long) {}
+
+        override fun onFinish() {
+            check = true
+        }
+    }.start()
+}
+
+@Composable
+fun PlayItemCard(title: String, duration: String, youtubeId: String, onEvent: (VideoEvent) -> Unit) {
+    OutlinedCard(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(5.dp)
+    ) {
+        Column(modifier = Modifier
+            .fillMaxWidth()
+            .padding(5.dp)
+            ){
+            Column {
+                Text(title)
+                Row(modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically){
+                    Text(duration)
+                    Row(modifier= Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.End) {
+                        IconButton(onClick = {
+                            onEvent(VideoEvent.DeleteVideoByYoutubeId(youtubeId))
+                        }) {
+                            Icon(
+                                imageVector = Icons.Default.Delete,
+                                contentDescription = "Delete video"
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
**Issues**
- Accessing the third-party YouTube library does not grant us to control over play and stop actions, and we lack the ability to access the current elapsed time of the playing video. Consequently, playing videos in the favourite list on loop becomes unfeasible.
- Initially, our database design stored only YouTube IDs to retain the IDs for all favourite videos. While this design was sufficient for the first mock-up, we now require human-readable titles and durations to represent videos instead of the ID.

**Refactoring/Fix**
- In response to the limitations of the third-party library, a workaround has been implemented by retrieving the duration of each video and setting up a counter to count down in parallel with the playing YouTube video, assuming that the user does not interfere with the time bar.
- The database schema was adjusted to include two new columns: title (String) and duration (String, in mm:ss format).
- When using the API to fetch playListItems from YouTube, it doesn't provide duration. To retrieve the duration, we can only pass individual YouTube IDs (id) with part and key to fetch the duration data. We introduced an iteration to loop through all playlistItems, utilizing the YouTube ID to fetch responses from YouTube and extract the duration data. Duration and title are now integral parts of the table columns and live data, accessible to views to display them to the users. 
- Both HomeScreen and FavouriteScreen have been enhanced to exhibit titles and durations instead of YouTube IDs.
- To elevate the user experience, a new PlayerScreen has been introduced. It features a player at the top and a list of favourite videos with titles and durations. The counter counts down from the duration of each video. When it reaches 0, the player proceeds to play the next video, looping back to the first video when reaching the end of the list. Additionally, reverse and forward buttons have been integrated to provide control over the playing videos.

Note: To rebuild a new database due to the schema change, either delete the SQLite file or wipe all data from the virtual device.

