### PR TITLE
Debug Or Refactor - Increment video heading's index number by 1

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -1,17 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="deploymentTargetDropDown">
-    <runningDeviceTargetSelectedWithDropDown>
-      <Target>
-        <type value="RUNNING_DEVICE_TARGET" />
-        <deviceKey>
-          <Key>
-            <type value="VIRTUAL_DEVICE_PATH" />
-            <value value="C:\Users\hiuhi\.android\avd\Pixel_5_API_30.avd" />
-          </Key>
-        </deviceKey>
-      </Target>
-    </runningDeviceTargetSelectedWithDropDown>
-    <timeTargetWasSelectedWithDropDown value="2023-12-05T16:21:53.397398500Z" />
+    <value>
+      <entry key="app">
+        <State />
+      </entry>
+    </value>
   </component>
 </project>

--- a/app/src/main/java/com/example/personalizedmusicapp/screen/HomeScreen.kt
+++ b/app/src/main/java/com/example/personalizedmusicapp/screen/HomeScreen.kt
@@ -142,7 +142,7 @@ fun ItemCard(
                     verticalAlignment = Alignment.CenterVertically
                 )
                 {
-                    Text(" ${item.snippet.position} - ${item.contentDetails.duration} ${item.snippet.title}")
+                    Text(" ${item.snippet.position.toInt() + 1} - ${item.contentDetails.duration} ${item.snippet.title}")
                 }
                 IconButton(onClick = {
                     if (isFound)


### PR DESCRIPTION
Issue:
After fetching a YouTube playlist from the Home screen, the screen will display a list of videos with headings like this: 
0 - 03:27 Video Title Aaa
1 - 02:04 Video Title Bbb
2 - 01:56 Video Title Ccc

The suggestion is to change the initial index from 0-based to 1-based, which will be more user-friendly, i.e.
1 - 03:27 Video Title Aaa
2 - 02:04 Video Title Bbb
3 - 01:56 Video Title Ccc

Fix: 
Updated HomeScreen.kt to increment the initial index value by one for each video's heading.