### PR TITLE
Debug Or Refactor - Display a spinning wheel when loading API data

### DIFF
--- a/app/src/main/java/com/example/personalizedmusicapp/screen/HomeScreen.kt
+++ b/app/src/main/java/com/example/personalizedmusicapp/screen/HomeScreen.kt
@@ -1,6 +1,7 @@
 package com.example.personalizedmusicapp.screen
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -8,12 +9,14 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.outlined.FavoriteBorder
 import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -98,6 +101,15 @@ fun HomeScreen(
                     .padding(5.dp)
             ) {
                 Text("Clear ID")
+            }
+        }
+
+        if (state.isLoading) {
+            Box(
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                // Show a spinning wheel
+                CircularProgressIndicator(modifier = Modifier.size(50.dp).align(Alignment.Center))
             }
         }
 

--- a/app/src/main/java/com/example/personalizedmusicapp/viewModel/VideoState.kt
+++ b/app/src/main/java/com/example/personalizedmusicapp/viewModel/VideoState.kt
@@ -15,4 +15,6 @@ data class VideoState(
     var playlistItems : List<Item> = emptyList(),
     // Store a complete video list of data fetched from Room
     val videos: List<Video> = emptyList(),
+    // Store a boolean value to indicate if it is loading API data
+    val isLoading: Boolean = false
 )

--- a/app/src/main/java/com/example/personalizedmusicapp/viewModel/VideoViewModel.kt
+++ b/app/src/main/java/com/example/personalizedmusicapp/viewModel/VideoViewModel.kt
@@ -32,10 +32,12 @@ class VideoViewModel (private val dao: VideoDao): ViewModel() {
 
     fun updatePlaylistItems(playlistId: String){
         viewModelScope.launch{
+            _state.value = _state.value.copy(isLoading = true)
             val part = "snippet"
             val maxResults = "50"
             val key = BuildConfig.API_KEY
             _playlistItems.value  = repo.getPlaylistItems(part, maxResults, playlistId, key)
+            _state.value = _state.value.copy(isLoading = false)
         }
     }
 


### PR DESCRIPTION
Issue:
After pressing the "Fetch Playlist" button on the Home screen, there is no spinning wheel to indicate whether the app has started fetching data or not. Users may be wondering if the button is not working or if the data has already finished loading.

Solution:
- Updated the "VideoState" class to include a new property "isLoading".
- Updated the "VideoViewModel" to set "isLoading" to "true" before making the API call and to "false" after the call is completed.
- Added a "CircularProgressIndicator" composable in "HomeScreen.kt" for displaying a spinning wheel when loading API data (i.e. when "isLoading" equals to "true").